### PR TITLE
remove a useless warning without context

### DIFF
--- a/Source/RimStory/Harmony/IncidentWorker_TryExecute.cs
+++ b/Source/RimStory/Harmony/IncidentWorker_TryExecute.cs
@@ -36,7 +36,5 @@ internal class IncidentWorker_TryExecute
                 Resources.eventsLog.Add(new IncidentShort(Utils.CurrentDate(), $"RS_{__instance.def.defName}"));
                 break;
         }
-
-        Log.Warning(__instance.def.defName);
     }
 }


### PR DESCRIPTION
In devmode it's annoying, it triggers on any incident, logs on context and presumably nobody cares.